### PR TITLE
Allowing (at) to be used instead of @ for email

### DIFF
--- a/index.js
+++ b/index.js
@@ -52,7 +52,7 @@ function render(resume) {
         github_account = getNetwork(profiles, 'github');
 
     if (hasEmail(resume)) {
-        resume.basics.gravatar = gravatar.url(resume.basics.email, {
+        resume.basics.gravatar = gravatar.url(resume.basics.email.replace('(at)', '@'), {
             s: '100',
             r: 'pg',
             d: 'mm'


### PR DESCRIPTION
This pull request stops the email address being listed in a format that is easier to scan for in search engines and stuff. 
