### PR TITLE
Update the Spotify profile URL.

### DIFF
--- a/index.js
+++ b/index.js
@@ -75,7 +75,7 @@ function getUrlFromUsername( site, username ) {
             return 'skype:' + username + '?call';
         case 'reddit':
         case 'spotify':
-            return '//' + url_map[ site ] + '/user/' + username;
+            return '//' + 'open.' + url_map[ site ] + '/user/' + username;
         default:
             return '//' + url_map[ site ] + '/' + username;
     }


### PR DESCRIPTION
This fixes #28. Change the URL to follow the format: http://open.spotify.com/user/username.