### PR TITLE
Normalize Gravatar image size

### DIFF
--- a/assets/css/theme.css
+++ b/assets/css/theme.css
@@ -275,6 +275,10 @@ body {
     padding: 10px 0;
   }
 }
+.profile-pic img {
+  width: 100px;
+  height: 100px;
+}
 @media (max-width: 992px) {
   .name {
     margin-top: 10px;

--- a/assets/less/info_card_styles.less
+++ b/assets/less/info_card_styles.less
@@ -12,6 +12,11 @@
     }
 }
 
+.profile-pic img {
+    width: 100px;
+    height: 100px;
+}
+
 .name {
     @media (max-width: @screen-desktop) {
         margin-top: 10px;

--- a/resume.template
+++ b/resume.template
@@ -109,8 +109,8 @@
             {{#resume.basics}}
               <span class="profile-pic-container">
                 <div class="profile-pic">
-                  <img class="media-object img-circle center-block"  data-src="holder.js/64x64"
-                    alt="64x64" src="{{picture}}" style="width: 100px; height: 100px;" itemprop="image">
+                  <img class="media-object img-circle center-block"  data-src="holder.js"
+                    alt="{{name}}" src="{{picture}}" itemprop="image">
                 </div>
 
                 <div class="name-and-profession">


### PR DESCRIPTION
My Gravatar image was coming out unpleasantly blurry juxtaposed with the rest of this fine, sharp layout. Removed the CSS enlarging the image by 20px, and normalized the loaded image and the image's defined style to 100px. This should fix #30.