### PR TITLE
Added build task that generates index.html and associated files in build folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules/*
 resume.json
+build/*

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -20,6 +20,34 @@ module.exports = function(grunt) {
         exec: {
             run_server: {
                 cmd: "node serve.js"
+            },
+            build_index: {
+                cmd: "node render.js"
+            }
+        },
+        copy: {
+            resumejson: {
+                cwd: './',
+                src: [ 'resume.json' ],
+                dest: './node_modules/resume-schema',
+                expand: true
+            },
+            build: {
+                cwd: './assets/css',
+                src: [ 'theme.css' ],
+                dest: './build/assets/css',
+                expand: true
+            },
+            favicon: {
+                cwd: './',
+                src: [ 'favicon.ico' ],
+                dest: './build/',
+                expand: true
+            }
+        },
+        clean: {
+            build: {
+                src: [ 'build' ]
             }
         }
     });
@@ -33,6 +61,30 @@ module.exports = function(grunt) {
     // Load the plugin to execute shell commands
     grunt.loadNpmTasks('grunt-exec');
 
+    // Load the plugin to clean directories
+    grunt.loadNpmTasks('grunt-contrib-clean')
+
+    // Load the plugin to copy files
+    grunt.loadNpmTasks('grunt-contrib-copy');
+
     // Default tasks
     grunt.registerTask('default', ['exec']);
+    grunt.registerTask('build', [ 
+        /* Uncomment this item once you've created your own resume.json file 
+           in the project root.  This will use your own data to build your site.
+         */
+        // 'copy:resumejson',
+        'clean', 
+        'copy:build', 
+        'exec:build_index' //,
+        /* Uncomment this item (and the comma above) if you add a favicon.ico 
+           in the project root. You'll also need to uncomment the <link...> tag
+           at the top of resume.template.
+         */
+        // 'copy:favicon'
+    ]);
+    grunt.registerTask('serve', [
+        'build',
+        'exec:run_server'
+    ])
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jsonresume-theme-elegant",
-  "version": "0.9.3",
+  "version": "0.9.4",
   "description": "Elegant theme for jsonresume",
   "main": "index.js",
   "scripts": {
@@ -34,6 +34,8 @@
     "grunt-contrib-less": "^0.11.4",
     "grunt-contrib-watch": "^0.6.1",
     "grunt-exec": "^0.4.6",
+    "grunt-contrib-copy": "0.4.x",
+    "grunt-contrib-clean": "0.5.x",
     "less": "^1.7.5",
     "underscore.string": "^2.3.3"
   }

--- a/render.js
+++ b/render.js
@@ -1,0 +1,27 @@
+//
+// This script will render the response and write it to the index.html file.
+//
+// Usage:
+// `node render`
+//
+
+var fs = require('fs');
+var resume = require("resume-schema").resumeJson;
+var theme = require("./index.js");
+
+fs.writeFile("./build/index.html", render(), function(err) {
+    if(err) {
+        console.log(err);
+    } else {
+        console.log("index.html written to build folder.");
+    }
+}); 
+
+function render() {
+    try {
+        return theme.render(resume);
+    } catch (e) {
+        console.log(e.message);
+        return "";
+    }
+}

--- a/resume.template
+++ b/resume.template
@@ -7,6 +7,7 @@
     <title>{{#resume.basics}}{{name}}{{/resume.basics}}</title>
     <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.2.0/css/font-awesome.min.css">
     <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.2.0/css/bootstrap.min.css">
+    <!-- link rel="shortcut icon" href="favicon.ico" / -->
     <style>
       {{{css}}}
     </style>


### PR DESCRIPTION
I added grunt tasks and associated JavaScript and config changes for a that generates a basic site served as index.html and linked CSS/JS.  This is useful for folks who build their site using node.js for dev, but deploy it as statically served HTML/CSS/JS, as I do (and as anyone using GitHub pages for their site will be).

Happy to discuss.