### PR TITLE
Remove floating-nav items for existing but empty objects

### DIFF
--- a/index.js
+++ b/index.js
@@ -10,9 +10,10 @@ utils.setConfig({
 function interpolate(object, keyPath) {
     var keys = keyPath.split('.');
 
-    return _(keys).reduce(function(res, key) {
+    return !_.isEmpty(
+      _(keys).reduce(function(res, key) {
         return (res || {})[key];
-    }, object);
+    }, object));
 }
 
 function getFloatingNavItems(resume) {


### PR DESCRIPTION
As I wrote in #49 the floating-nav can contain items for sections that are not rendered because in fact the properties are just there in the json file but without any content.

Maybe adding the isEmpty check is a good idea because it is more flexible? 
In the end it does remove floating-nav items in both cases (property non existing or property is there but empty, like `"awards": []`) so that the floating-nav will always match the actual document.