### PR TITLE
Fixing deprecation warning for moment constructor

### DIFF
--- a/index.js
+++ b/index.js
@@ -75,8 +75,8 @@ function render(resume) {
     resume.basics.remaining_profiles = resume.basics.profiles.slice(5);
 
     _.each(resume.work, function(work_info) {
-        var start_date = moment(work_info.startDate);
-        var end_date = work_info.endDate;
+        var start_date = moment(work_info.startDate, "YYYY-MM-DD");
+        var end_date = moment(work_info.endDate, "YYYY-MM-DD");
         var did_leave_company = !!end_date;
 
         if (end_date) {


### PR DESCRIPTION
Currently, the shell outputs a deprecation warning for `moment` construction and the app falls back to vanilla Date because the parameter format is incorrect – see moment/moment#1407.

This PR fixes the situation by providing a format, as specified by JSON Resume Schema: `YYYY-MM-DD`.

It also makes start and end date consistent as end date hasn't used _moment_ before.