### PR TITLE
Do not mutate original resume to avoid bugs on subsequent server requests

### DIFF
--- a/serve.js
+++ b/serve.js
@@ -23,7 +23,7 @@ console.log("Serving..");
 
 function render() {
     try {
-        return theme.render(resume);
+        return theme.render(JSON.parse(JSON.stringify(resume)));
     } catch (e) {
         console.log(e.message);
         return "";


### PR DESCRIPTION
Hi there,
I found a little tricky bug that appears while working with the development server.

Basically, the `resume` JSON file is cached as an object after the first time it is loaded within `server.js`, which is [expected] (https://nodejs.org/api/modules.html#modules_caching) Node.js behavior. Meanwhile, any call to the `render` function will mutate the `resume` object it is given as an argument. Therefore, if `render`doesn't use a **deep clone** of the original `resume` object as an argument, any subsequent request to the running local development server will imply that the `render` function will be given a *modified* version of the original `resume` (modified by `render` itself ironically). This leads to some unexpected behavior.

Here is an illustration of this behavior. Consider the value of the start date of the first item of the work section, `resume.work[0].startDate`. Let's name it `startDate` and let's describe and reproduce step by step the following bug:

- We call `localhost:8888` using the Chrome browser. The `/` page is requested and, as a result, the `render` function will assign the value `Dec, 2013` to `startDate`. This is what we will be rendered in the browser. Nothing fancy here. So basically
 ```
> utils.getFormattedDate(moment("2013-12-01", "YYYY-MM-DD"))
'Dec, 2013'
 ```

- Meanwhile, the browser makes an automatic request to the `/favicon.ico` page. As `Dec, 2013`  is now the value of `startDate`, what will happen within `render` is roughly the following
 ```
> utils.getFormattedDate(moment("Dec, 2013", 
"YYYY-MM-DD"))
'Jan, 2013'
 ```

- So quite astonishingly, `Jan, 2013` is now the date that `resume` stores, *instead of* the expected `Dec, 2013`!  Therefore on the next page refresh in the browser, `Jan, 2013` will be the date that will be rendered, due to
 ```
> utils.getFormattedDate(moment("Jan, 2013", "YYYY-MM-DD"))
'Jan, 2013'
 ```

Alternatively, if you run twice `$ curl  'http://localhost:8888'` you'll notice the same wrong start date appearing in the output of the second "curl".

Another consequence of this modified `resume` being handed over is that the deprecation warning of the moment constructor will also show up when making a request to the running server for the second time.