### PR TITLE
Fixed tooltip bug for social icons

### DIFF
--- a/jade/profile-card.jade
+++ b/jade/profile-card.jade
@@ -13,7 +13,7 @@ mixin render_links(profiles)
     a.fs-2x.social-link(
       href=profile.url,
       target="_blank",
-      rel="tooltip",
+      data-toggle="tooltip",
       title= resume.basics.name + " on " + profile.network,
       class="link-" + profile.label + " icon-" + profile.label)
 


### PR DESCRIPTION
My PR #63 introduced a bug where tooltips would no longer show for social icons. Now fixed.