### PR TITLE
Use unpkg to serve fonts instead of inlining base64 font

### DIFF
--- a/assets/less/base.less
+++ b/assets/less/base.less
@@ -1,5 +1,6 @@
 @import "variables";
 @import "mixins";
+@import "icon";
 
 body {
     font-family: 'Lato';

--- a/assets/less/icon.less
+++ b/assets/less/icon.less
@@ -1,0 +1,18 @@
+@theme-version: '1.6.10';
+@font-base-path: "http://unpkg.com/jsonresume-theme-elegant@@{theme-version}/assets/icomoon/fonts";
+
+@font-face {
+  font-family: 'jst-elegant';
+  src:  url("@{font-base-path}/icomoon.eot?f218wo");
+  src:  url("@{font-base-path}/icomoon.eot?f218wo#iefix") format('embedded-opentype'),
+    url("@{font-base-path}/icomoon.ttf?f218wo") format('truetype'),
+    url("@{font-base-path}/icomoon.woff?f218wo") format('woff'),
+    url("@{font-base-path}/icomoon.svg?f218wo#icomoon") format('svg');
+  font-weight: normal;
+  font-style: normal;
+}
+
+[class^="icon-"], [class*=" icon-"] {
+  /* use !important to prevent issues with browser extensions that change fonts */
+  font-family: 'jst-elegant' !important;
+}


### PR DESCRIPTION
it was hard to update icons, this way it enables anyone to be able to update icons