### PR TITLE
Fix for "Invalid Date" appearing on CV

### DIFF
--- a/index.js
+++ b/index.js
@@ -86,23 +86,23 @@ function render(resume) {
     resume.basics.remaining_profiles = resume.basics.profiles.slice(5);
 
     _.each(resume.work, function(work_info) {
-        var end_date;
         var start_date = moment(work_info.startDate, "YYYY-MM-DD");
-        var did_leave_company = !!work_info.endDate;
+        var end_date = moment(work_info.endDate, "YYYY-MM-DD");
+        var can_calculate_period = start_date.isValid() && end_date.isValid();
 
-        work_info.summary = convertMarkdown(work_info.summary);
-
-        if (work_info.endDate) {
-            end_date = moment(work_info.endDate, "YYYY-MM-DD");
-            work_info.endDate = utils.getFormattedDate(end_date);
-        }
-
-        if (start_date) {
-            end_date = end_date ? moment(end_date) : moment();
-            work_info.startDate = utils.getFormattedDate(start_date);
-
+        if (can_calculate_period) {
             work_info.duration = moment.preciseDiff(start_date, end_date);
         }
+
+        if (start_date.isValid()) {
+          work_info.startDate = utils.getFormattedDate(start_date);
+        }
+
+        if (end_date.isValid()) {
+          work_info.endDate = utils.getFormattedDate(end_date);
+        }
+
+        work_info.summary = convertMarkdown(work_info.summary);
 
         work_info.highlights = _(work_info.highlights).map(function(highlight) {
             return convertMarkdown(highlight);


### PR DESCRIPTION
If an endDate of a `work` object is null or not adhering to the YYYY-MM-DD formats, the CV would list "Invalid Date", which in my opinion is wrong at least for the current role, where endDate will be null, or maybe a given string like "Present".

I also tidied up the code around the date management to use less variables, avoid late initialisation of them, more consistent `if` statements and using the `isValid` method of moment to ensure we only use the dates if they are correct.

The behaviour in place now is:

* Calculates start and end date.
* If start date is valid, format it appropriately.
* If end date is valid, format it appropriately.
* If both dates are valid, calculate the period.

Cheers!

PS: Thanks for the theme, looks really nice!