### PR TITLE
Adapt StackOverflow Icon Color

### DIFF
--- a/assets/css/theme.css
+++ b/assets/css/theme.css
@@ -714,12 +714,12 @@ body {
   color: #d31e40;
 }
 .link-stackoverflow {
-  color: #8e8e92;
+  color: #f48024;
 }
 .link-stackoverflow:hover,
 .link-stackoverflow:focus {
   text-decoration: none;
-  color: #747479;
+  color: #da670b;
 }
 .link-stackexchange {
   color: #62b0df;

--- a/assets/less/variables.less
+++ b/assets/less/variables.less
@@ -28,7 +28,7 @@
 @tumblr-color: #2d4661;
 @instagram-color: #e4405f;
 @gratipay-color: #630;
-@stackoverflow-color: rgb(142, 142, 146);
+@stackoverflow-color: #f48024;
 @stackexchange-color: rgb(98, 176, 223);
 @lastfm-color: #d12127;
 @pinterest-color: rgb(189, 9, 31);


### PR DESCRIPTION
I noticed that the icon color for StackOverflow is different from the actual orange of the CI which actually makes it look unstyled compared to other icons: 
![image](https://user-images.githubusercontent.com/35292572/122646972-3d272180-d122-11eb-8cc1-374aac4933d0.png)

There once was a PR #94 that already adapted the color but somehow the color got changed again. With this PR, the icon looks like this: 
![image](https://user-images.githubusercontent.com/35292572/122646998-6778df00-d122-11eb-9f8e-95588a45c0ad.png)
